### PR TITLE
Move away from kompose/app and add sanitize functionality

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -5,8 +5,8 @@ import (
 	"os"
 
 	log "github.com/sirupsen/logrus"
+	"github.com/trawler/komposify/pkg/cna"
 
-	"github.com/kubernetes/kompose/pkg/app"
 	"github.com/kubernetes/kompose/pkg/kobject"
 	"github.com/spf13/cobra"
 )
@@ -21,8 +21,6 @@ var rootCmd = &cobra.Command{
 	Use:   "komposify",
 	Short: "Komposify is a tool for automating Kompose handling of Docker Compose/Stack Files.",
 
-	// Uncomment the following line if your bare application
-	// has an action associated with it:
 	PersistentPreRun: func(cmd *cobra.Command, args []string) {
 
 		// Add extra logging when verbosity is passed
@@ -40,9 +38,12 @@ var rootCmd = &cobra.Command{
 		ConvertOpt := kobject.ConvertOptions{
 			CreateChart: true,
 			InputFiles:  ComposeFiles,
+			CreateD:     true,
 			OutFile:     "compose-helm",
+			Provider:    "kubernetes",
 		}
-		app.Convert(ConvertOpt)
+
+		cna.Convert(ConvertOpt)
 	},
 }
 
@@ -57,5 +58,5 @@ func Execute() {
 
 func init() {
 	rootCmd.PersistentFlags().BoolVarP(&Verbose, "verbose", "v", false, "verbose output")
-	rootCmd.PersistentFlags().StringArrayVarP(&ComposeFiles, "file", "f", []string{}, "Specify an alternative compose file")
+	rootCmd.PersistentFlags().StringArrayVarP(&ComposeFiles, "file", "f", []string{}, "Input compose file(s)")
 }

--- a/pkg/cna/convert.go
+++ b/pkg/cna/convert.go
@@ -1,0 +1,60 @@
+package cna
+
+import (
+	"log"
+
+	"github.com/kubernetes/kompose/pkg/kobject"
+	"github.com/kubernetes/kompose/pkg/loader"
+	"github.com/kubernetes/kompose/pkg/transformer"
+	"github.com/kubernetes/kompose/pkg/transformer/kubernetes"
+)
+
+// Convert transforms and sanitizes docker compose or dab file to k8s objects
+func Convert(opt kobject.ConvertOptions) error {
+	komposeObject, err := getKomposeObject(opt)
+	if err != nil {
+		return nil
+	}
+	// Modify the Kompose Object
+	newKompose := sanitize(komposeObject)
+
+	// Get a transformer that maps komposeObject to provider's primitives
+	t := getTransformer(opt)
+
+	// Do the transformation
+	objects, err := t.Transform(newKompose, opt)
+	if err != nil {
+		log.Fatalf(err.Error())
+	}
+
+	// Print output
+	err = kubernetes.PrintList(objects, opt)
+	if err != nil {
+		log.Fatalf(err.Error())
+	}
+	return nil
+}
+
+func getKomposeObject(opt kobject.ConvertOptions) (*kobject.KomposeObject, error) {
+	komposeObject := kobject.KomposeObject{
+		ServiceConfigs: make(map[string]kobject.ServiceConfig),
+	}
+
+	l, err := loader.GetLoader("compose")
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	komposeObject, err = l.LoadFile(opt.InputFiles)
+	if err != nil {
+		log.Fatalf(err.Error())
+	}
+	return &komposeObject, nil
+}
+
+// Convenience method to return the appropriate Transformer based on
+// what provider we are using.
+func getTransformer(opt kobject.ConvertOptions) transformer.Transformer {
+	// Create/Init new Kubernetes object with CLI opts
+	return &kubernetes.Kubernetes{Opt: opt}
+}

--- a/pkg/cna/sanitize.go
+++ b/pkg/cna/sanitize.go
@@ -1,0 +1,40 @@
+package cna
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/kubernetes/kompose/pkg/kobject"
+)
+
+func sanitize(kObject *kobject.KomposeObject) kobject.KomposeObject {
+	deleteDockerLbLabels(kObject)
+	deleteSecrets(kObject)
+	return *kObject
+}
+
+func deleteSecrets(opt *kobject.KomposeObject) {
+	//for secret := range opt.Secrets {
+	//}
+}
+
+func deleteDockerLbLabels(opt *kobject.KomposeObject) {
+	for svc := range opt.ServiceConfigs {
+		deployLabels := opt.ServiceConfigs[svc].DeployLabels
+		for key := range deployLabels {
+			if strings.HasPrefix(key, "com.docker.lb") {
+				delete(deployLabels, key)
+			}
+		}
+	}
+}
+
+// PrettyPrint prints data structs for debugging
+func PrettyPrint(v interface{}) (err error) {
+	b, err := json.MarshalIndent(v, "", "  ")
+	if err == nil {
+		fmt.Println(string(b))
+	}
+	return nil
+}

--- a/vendor/github.com/kubernetes/kompose/pkg/loader/compose/v3.go
+++ b/vendor/github.com/kubernetes/kompose/pkg/loader/compose/v3.go
@@ -155,7 +155,6 @@ func loadV3Placement(constraints []string) map[string]string {
 			label := strings.TrimPrefix(p[0], "node.labels.")
 			placement[label] = p[1]
 		} else {
-
 			log.Warn(p[0], errMsg)
 		}
 	}


### PR DESCRIPTION
This PR:
- Removes the dependency to kompose/app and creates pkg/cna/convert.
- Add `sanitize` function.
- Removes `com.docker.lb` labels.
- Fixes patch to kompose v3 node.role manager/master label.